### PR TITLE
Fixed: Can't call reward type test ad

### DIFF
--- a/src/org/godotengine/godot/AdMob.java
+++ b/src/org/godotengine/godot/AdMob.java
@@ -89,7 +89,7 @@ public class AdMob {
 
             if (ad_unit_id.length() <= 0 || AdMobConfig.optBoolean("TestAds", false)) {
                 Utils.d("GodotFirebase", "AdMob:RewardedVideo:UnitId:NotProvidedOrTestAds:AddingTestAd");
-                ad_units.add(activity.getString(R.string.test_rewarded_video_ad_unit_id));
+                ad_unit_id += ","+activity.getString(R.string.test_rewarded_video_ad_unit_id);
             }
 
             reward_ads = new HashMap<String, RewardedAd>();
@@ -400,12 +400,10 @@ public class AdMob {
         AdRequest.Builder adRB = new AdRequest.Builder();
 
         // Covered with the test ad ID
-		/*
-		if (BuildConfig.DEBUG || AdMobConfig.optBoolean("TestAds", false)) {
-			adRB.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
-			adRB.addTestDevice(AdMobConfig.optString("TestDevice", Utils.getDeviceId(activity)));
-		}
-		*/
+	if (BuildConfig.DEBUG || AdMobConfig.optBoolean("TestAds", false)) {
+		adRB.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
+		adRB.addTestDevice(AdMobConfig.optString("TestDevice", Utils.getDeviceId(activity)));
+	}
 
         mrv.loadAd(adRB.build(), new RewardedAdLoadCallback() {
             @Override


### PR DESCRIPTION
Rewarded ads cannot be tested.